### PR TITLE
Add text file inventory system

### DIFF
--- a/bot/utils/files.py
+++ b/bot/utils/files.py
@@ -28,3 +28,40 @@ def cleanup_item_file(file_path: str) -> None:
         folder = os.path.dirname(file_path)
         if os.path.isdir(folder) and not os.listdir(folder):
             os.rmdir(folder)
+
+
+def ensure_lines_file(item_name: str) -> str:
+    """Return path to the inventory text file for the given item.
+
+    The file is created inside ``assets/lines`` and named using a sanitized
+    version of ``item_name``.  All directories are created if necessary.
+    """
+    folder = os.path.join("assets", "lines")
+    os.makedirs(folder, exist_ok=True)
+    return os.path.join(folder, f"{sanitize_name(item_name)}.txt")
+
+
+def pop_line_from_file(item_name: str) -> str | None:
+    """Pop and return the first non-empty line from the item's text file.
+
+    If the file does not exist or contains no lines, ``None`` is returned.
+    The popped line is removed from the file.
+    """
+    path = ensure_lines_file(item_name)
+    if not os.path.isfile(path):
+        return None
+
+    with open(path, "r+", encoding="utf-8") as f:
+        lines = f.readlines()
+        # Remove empty lines and preserve newline characters for remaining lines
+        lines = [ln for ln in lines if ln.strip()]
+        if not lines:
+            # Truncate file if it only contained empty lines
+            f.seek(0)
+            f.truncate()
+            return None
+        first = lines.pop(0).rstrip("\n")
+        f.seek(0)
+        f.truncate()
+        f.writelines([ln if ln.endswith("\n") else ln + "\n" for ln in lines])
+    return first

--- a/create_lines_files.py
+++ b/create_lines_files.py
@@ -1,0 +1,23 @@
+import os
+from bot.database import Database
+from bot.database.models import Goods
+from bot.utils.files import ensure_lines_file
+
+
+def main() -> None:
+    session = Database().session
+    items = session.query(Goods.name).all()
+    if not items:
+        print("No products found in database")
+        return
+    for name, in items:
+        path = ensure_lines_file(name)
+        if not os.path.isfile(path):
+            open(path, "a", encoding="utf-8").close()
+            print(f"Created {path}")
+        else:
+            print(f"Exists {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/markdown/quick_start.md
+++ b/markdown/quick_start.md
@@ -46,8 +46,13 @@
       ```
       NOWPAYMENTS_IPN_URL=https://xxxx.ngrok-free.app/nowpayments-ipn
       ```
-  7. Run run.py
-   8. Make sure your self-hosted nodes are up and RPC endpoints match the URLs above.
+7. Run run.py
+8. Make sure your self-hosted nodes are up and RPC endpoints match the URLs above.
+9. Initialize inventory files:
+   ```bash
+   python create_lines_files.py
+   ```
+   Add one product entry per line inside the created files in `assets/lines/`. These lines will be delivered to buyers.
 
 ### P.S.
 1. Add the bot to the channel and group you have provided and make it an admin


### PR DESCRIPTION
## Summary
- support per-product text file queues for inventory
- use inventory files when delivering a purchased item
- script `create_lines_files.py` to create empty files for existing products
- document new workflow in quick start guide

## Testing
- `python -m py_compile bot/utils/files.py bot/handlers/user/main.py create_lines_files.py`
- `pip install -r requirements.txt`
- `pip install python-dotenv`
- `python create_lines_files.py`

------
https://chatgpt.com/codex/tasks/task_b_686baf23808c8326be2bae791d3d11f1